### PR TITLE
Add optional progress callback to compress_multiple()

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -34,12 +34,13 @@ pyminizip.compress("/srcfile/path.txt", "/distfile/path.zip", "password", int(co
   Return value:
   - always returns None
 
-pyminizip.compress_multiple([u'pyminizip.so', 'file2.txt'], "file.zip", "1233", 4)
+pyminizip.compress_multiple([u'pyminizip.so', 'file2.txt'], "file.zip", "1233", 4, progress)
   Args:
   1. src file LIST path (list)
   2. dst file path (string)
   3. password (string) or None (to create no-password zip)
   4. compress_level(int) between 1 to 9, 1 (more fast)  <---> 9 (more compress)
+  5. optional function to be called during processing which takes one argument, the count of how many files have been compressed
 
   Return value:
   - always returns None

--- a/src/py_minizip.c
+++ b/src/py_minizip.c
@@ -341,12 +341,14 @@ int _compress(const char** srcs, int src_num, const char* dst, int level, const 
 
         if (progress != NULL)
         {
-            PyObject *args = PyTuple_New(1);
-            PyObject *count = PyInt_FromLong(i+1);
-            PyTuple_SetItem(args, 0, count);
-            PyObject_CallObject(progress, args);
-            Py_DECREF(args);
-            Py_DECREF(count);
+			PyObject* args = Py_BuildValue("(I)", i + 1);
+			PyObject* result = PyObject_CallObject(progress, args);
+			if (PyErr_Occurred()) // Ignore errors in the callback, don't want them to crash this c module
+			{
+				PyErr_Clear();
+			}
+			Py_XDECREF(result);
+			Py_XDECREF(args);
         }
 
     }

--- a/src/py_minizip.c
+++ b/src/py_minizip.c
@@ -204,7 +204,7 @@ int get_file_crc(const char* filenameinzip, void *buf, unsigned long size_buf, u
     return err;
 }
 
-int _compress(const char** srcs, int src_num, const char* dst, int level, const char* password, int exclude_path)
+int _compress(const char** srcs, int src_num, const char* dst, int level, const char* password, int exclude_path, PyObject* progress)
 {
     zipFile zf = NULL;
     int size_buf = WRITEBUFFERSIZE;
@@ -338,6 +338,17 @@ int _compress(const char** srcs, int src_num, const char* dst, int level, const 
                 err = ZIP_ERRNO;
             }
         }
+
+        if (progress != NULL)
+        {
+            PyObject *args = PyTuple_New(1);
+            PyObject *count = PyInt_FromLong(i+1);
+            PyTuple_SetItem(args, 0, count);
+            PyObject_CallObject(progress, args);
+            Py_DECREF(args);
+            Py_DECREF(count);
+        }
+
     }
 
     errclose = zipClose(zf, NULL);
@@ -378,7 +389,7 @@ static PyObject *py_compress(PyObject *self, PyObject *args)
         pass = NULL;
     }
 
-    res = _compress(&src, 1, dst, level, pass, 1);
+    res = _compress(&src, 1, dst, level, pass, 1, NULL);
 
     if (res != ZIP_OK) {
         return pyerr_msg;
@@ -399,8 +410,10 @@ static PyObject *py_compress_multiple(PyObject *self, PyObject *args)
     PyObject * str_obj; /* the list of strings */
     char * tmp;
 
-    if (!PyArg_ParseTuple(args, "Oz#z#i", &src, &dst, &dst_len, &pass, &pass_len, &level)) {
-        return PyErr_Format(PyExc_ValueError, "expected arguments are compress([src], dst, pass, level)");
+    PyObject * progress_cb_obj = NULL;
+
+    if (!PyArg_ParseTuple(args, "Oz#z#i|O", &src, &dst, &dst_len, &pass, &pass_len, &level, &progress_cb_obj)) {
+        return PyErr_Format(PyExc_ValueError, "expected arguments are compress([src], dst, pass, level, <progress>)");
     }
 
     src_len = PyList_Size(src);
@@ -419,6 +432,12 @@ static PyObject *py_compress_multiple(PyObject *self, PyObject *args)
 
     if (pass_len < 1) {
         pass = NULL;
+    }
+
+    if (progress_cb_obj != NULL) {
+        if (!PyFunction_Check(progress_cb_obj)) {
+            return PyErr_Format(PyExc_ValueError, "progress must be function or None");
+        }
     }
 
     srcs = (char **)malloc(src_len * sizeof(char *));
@@ -440,7 +459,7 @@ static PyObject *py_compress_multiple(PyObject *self, PyObject *args)
         Py_XDECREF(str_obj);
     }
 
-    res = _compress((const char **)srcs, src_len, dst, level, pass, 1);
+    res = _compress((const char **)srcs, src_len, dst, level, pass, 1, progress_cb_obj);
 
     // cleanup free up heap allocated memory
     for (i = 0; i < src_len; i++) {


### PR DESCRIPTION
This patch allows the progress of a compress_multiple() to be monitored. The optional new argument to compress_multiple is a function that accepts one argument, the count of files currently processed.

Usage is as such:
```
files = [u'pyminizip.so', 'file2.txt']
def progress(count):
    print "Compressed %d of %d" % (count, len(files))

pyminizip.compress_multiple(files, "file.zip", "1233", 4, progress)
```