### PR TITLE
Added zlib123 directory to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,12 @@
 graft src
-graft zlib123
+recursive-include zlib123 *.c *.h
+recursive-exclude zlib123 ChangeLog configure FAQ INDEX Makefile* make_vms.com README
+prune zlib123/amiga
+prune zlib123/as400
+prune zlib123/contrib
+prune zlib123/examples
+prune zlib123/msdos
+prune zlib123/old
+prune zlib123/projects
+prune zlib123/qnx
+prune zlib123/win32

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 graft src
+graft zlib123


### PR DESCRIPTION
@smihica I noticed that directory zlib123 was missing on MANIFEST.in and this prevented sources on pypi to be compiled.
I tried the setuptools `sdist` command after this fix and now it seems that source package is OK.