### PR TITLE
Fix _compress(): don't add slash on filepath if prefix is an empty st…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(fname):
 
 setup(
     name = 'pyminizip',
-    version = '0.2.4',
+    version = '0.2.4.1',
     description = 'A minizip wrapper - To create a password encrypted zip file in python.',
     author='Shin Aoyama',
     author_email = "smihica@gmail.com",

--- a/src/py_minizip.c
+++ b/src/py_minizip.c
@@ -319,8 +319,14 @@ int _compress(const char** srcs, int src_num, const char** srcspath, int srcpath
                         slash = &default_slash;
                     }
                 }
-                if (savefilepathnameinzip[filepathname_len-1] != *slash)
-                    extra_len = 1;
+
+                /* NOTE:
+                    don't add slash if filepathname_len is zero (prefix is an empty string)
+                    and avoid memory access violation */
+                if (filepathname_len > 0) {
+                    if (savefilepathnameinzip[filepathname_len-1] != *slash)
+                        extra_len = 1;
+                }
                 /* allocate buffer */
                 fullpathfileinzip = (char *)malloc(filename_len + filepathname_len + extra_len + 1);
                 if (fullpathfileinzip == NULL) {


### PR DESCRIPTION
Currently **compress_multiple** method allows adding all files in the root of the archive (second param set as an empty list) or adding files inside a specific folder (second param set as a list of paths).

This PR allows to use **compress_multiple** method in a hybrid scenario, that is archiving some files in the archive root (second param set as empty string at the corresponding list item) and other files in specific folders (second param set as folder path at the corresponding list item).

E.g. 

```python
pyminizip.compress_multiple(["/usr/tmp/a.txt", "/usr/tmp/b.txt"], ["", "testdir"], "/tmp/test.zip", None, 5)
```
Result:
* **test.zip**
  * a.txt
  * **testdir**/b.txt