### PR TITLE
update setup.py for python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
         "Development Status :: 3 - Alpha",
         "Environment :: Other Environment",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Currently, pyminizip is not recognized by pypi or vscode as a module that can be used within the python3

https://pypi.org/project/pyminizip/
![image](https://user-images.githubusercontent.com/75910092/142982500-4d6f4167-9b3f-4067-a543-59a2c67eedec.png)
