### PR TITLE
Add build CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-11]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.3
+        env:
+          # Only build 64-bit wheels
+          CIBW_ARCHS: auto64
+          # Disable building PyPy wheels
+          CIBW_SKIP: pp*
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz

--- a/upload.sh
+++ b/upload.sh
@@ -1,1 +1,0 @@
-rm -rf ./dist ./pyminizip.egg-info && python3 setup.py sdist && twine upload dist/*


### PR DESCRIPTION
Hey :)

I noticed installing `pyminizip` is impossible on minimal environments that lack build tools (i.e. `python:slim`, `python:alpine` containers).
Figured I'd open a PR to have wheels for this package, to make installation easier for users.

#### Advantages of shipping wheels
- No build tools (i.e. gcc) are necessary for installation.
- Installation is ~10x faster (~0.38s vs. ~3.7s in a container on my local machine).
- Wheels are 5x smaller than sdists on Windows/macOS (only marginally smaller on Linux for some reason).

#### Wheel compatibility
Using `cibuildwheel` is super easy for build automation (Great simple template [here](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml)) and it only takes a couple of minutes to run.

At least as a start I've set it to build Intel 64-bit CPython wheels, for 3.6-3.11 (all supported versions in cibuildwheel).
Added workflow also has a job for building a source distribution, to have everything needed for a PyPI release :)

Checking info on [pypistats.org](https://pypistats.org/packages/pyminizip) it seems like >99% of users are Linux Python 3.7+, so **almost every user should benefit**.
I kept the default `manylinux2014` image, as pretty much every Python 3.7 user is compatible with it.
A small amount of users will still not get wheels because they have an old version of `pip` not supporting `manylinux2014` (See stats [here](https://mayeut.github.io/manylinux-timeline/)).

Anyway - any user with an unsupported platform/old pip will just fallback to the existing behavior and get the `sdist`.

#### List of build artifacts
Example build: https://github.com/ben9923/pyminizip/actions/runs/3170412445
```
pyminizip-0.2.6-cp36-cp36m-macosx_10_9_x86_64.whl
pyminizip-0.2.6-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
pyminizip-0.2.6-cp36-cp36m-musllinux_1_1_x86_64.whl
pyminizip-0.2.6-cp36-cp36m-win_amd64.whl
pyminizip-0.2.6-cp37-cp37m-macosx_10_9_x86_64.whl
pyminizip-0.2.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
pyminizip-0.2.6-cp37-cp37m-musllinux_1_1_x86_64.whl
pyminizip-0.2.6-cp37-cp37m-win_amd64.whl
pyminizip-0.2.6-cp38-cp38-macosx_10_9_x86_64.whl
pyminizip-0.2.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
pyminizip-0.2.6-cp38-cp38-musllinux_1_1_x86_64.whl
pyminizip-0.2.6-cp38-cp38-win_amd64.whl
pyminizip-0.2.6-cp39-cp39-macosx_10_9_x86_64.whl
pyminizip-0.2.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
pyminizip-0.2.6-cp39-cp39-musllinux_1_1_x86_64.whl
pyminizip-0.2.6-cp39-cp39-win_amd64.whl
pyminizip-0.2.6-cp310-cp310-macosx_10_9_x86_64.whl
pyminizip-0.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
pyminizip-0.2.6-cp310-cp310-musllinux_1_1_x86_64.whl
pyminizip-0.2.6-cp310-cp310-win_amd64.whl
pyminizip-0.2.6-cp311-cp311-macosx_10_9_x86_64.whl
pyminizip-0.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
pyminizip-0.2.6-cp311-cp311-musllinux_1_1_x86_64.whl
pyminizip-0.2.6-cp311-cp311-win_amd64.whl
pyminizip-0.2.6.tar.gz
```

### Upload suggestion
It seems like `0.2.6 == master`.
In case it's merged, it would be cool to have those wheels uploaded to PyPI for the current release, instead of waiting for a future release (unless one is planned soon).

I also removed `upload.sh` which shouldn't really be involved when sdist+wheels are created by CI.

Related to #11 