### PR TITLE
Build wheels with GitHub actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-11]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.11.2
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
GitHub actions now makes it easy to auto-build binary wheels!

I've used the fantastic tool & example from here quite successfully for this MR:  https://github.com/pypa/cibuildwheel

This can also be extended to auto-upload releases (got tag) to PyPI, see docs & example:
* https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
* https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/#github-actions

Here's one of the build jobs from my fork: https://github.com/andrewleech/pyminizip/actions/runs/3391731405/jobs/5637174110

And all the built wheels can be downloaded in the artifact zip link at the bottom of: https://github.com/andrewleech/pyminizip/actions/runs/3391731405