### PR TITLE
Allow for progress_cb_obj to be a callable or None

### DIFF
--- a/src/py_minizip.c
+++ b/src/py_minizip.c
@@ -534,8 +534,8 @@ static PyObject *py_compress_multiple(PyObject *self, PyObject *args)
     }
 
     if (progress_cb_obj != NULL) {
-        if (!PyFunction_Check(progress_cb_obj)) {
-            return PyErr_Format(PyExc_ValueError, "progress must be function or None");
+        if (!PyCallable_Check(progress_cb_obj)) {
+            return PyErr_Format(PyExc_ValueError, "progress must be callable or None");
         }
     }
 


### PR DESCRIPTION
Check the `progress` object with `PyCallable_Check` which has the same signature than `PyFunction_Check`.

> `int PyFunction_Check(PyObject *o)`
> Return true if o is a function object (has type PyFunction_Type). The parameter must not be NULL.

vs

> `int PyCallable_Check(PyObject *o)`
> Determine if the object o is callable. Return 1 if the object is callable and 0 otherwise. This function always succeeds.

This commit closes https://github.com/smihica/pyminizip/issues/46